### PR TITLE
[PKG-8878] aiokafka 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python
     - pip
     - setuptools >=77
+    - wheel
     - zlib
   run:
     - python
@@ -82,6 +83,7 @@ about:
   description: |
     AIOKafkaProducer is a high-level, asynchronous message producer.
   dev_url: https://github.com/aio-libs/aiokafka
+  doc_url: https://aiokafka.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -25,8 +26,7 @@ requirements:
     - python
     - pip
     - setuptools >=77
-    - wheel
-    - zlib
+    - zlib {{ zlib }}
   run:
     - python
     - async-timeout

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,11 +57,8 @@ test:
     - mv gh_src/tests tests    # [not win]
     # Configure flags and docker image name (for unix only)
     # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L3-L6
-    - export FLAGS=--maxfail=3    # [not win]
-    - export SCALA_VERSION=2.13   # [not win]
-    - export KAFKA_VERSION=2.8.1  # [not win]
-    - export DOCKER_IMAGE=aiolibs/kafka:$(SCALA_VERSION)_$(KAFKA_VERSION)  # [not win]
-    - export LOG_FORMAT="%(asctime)s %(levelname)s %(message)s"            # [not win]    
+    - set FLAGS=--maxfail=3     # [win]
+    - export FLAGS=--maxfail=3  # [not win]
     # Invoke tests like from the Makefile
     # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L59
     #
@@ -69,7 +66,14 @@ test:
     # Docker is not available on Windows, do not pass a docker image
     # to skip its tests (they are fine on unix).
     - pytest -s -v --log-level DEBUG %FLAGS% tests    # [win]
-    - pytest -s -v --log-format="$LOG_FORMAT" --log-level DEBUG --docker-image=$(DOCKER_IMAGE) $(FLAGS) tests  # [not win]
+    # We decided to skip the docker tests for unix as well on our build system.
+    # To run tests locally comment this line and un-comment the lines below it.
+    - export LOG_FORMAT="%(asctime)s %(levelname)s %(message)s"                 # [not win]    
+    - pytest -s -v --log-format="$LOG_FORMAT" --log-level DEBUG $(FLAGS) tests  # [not win]
+    # - export SCALA_VERSION=2.13   # [not win]
+    # - export KAFKA_VERSION=2.8.1  # [not win]
+    # - export DOCKER_IMAGE=aiolibs/kafka:$(SCALA_VERSION)_$(KAFKA_VERSION)  # [not win]
+    # - pytest -s -v --log-format="$LOG_FORMAT" --log-level DEBUG --docker-image=$(DOCKER_IMAGE) $(FLAGS) tests  # [not win]
 
 about:
   home: https://github.com/aio-libs/aiokafka

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,28 +50,25 @@ test:
     - pyproject.toml
   commands:
     - pip check
-    # check that pip gets the correct version 
+    # Check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    # move tests in the root folder (where pyproject.toml is)
+    # Move tests in the root folder (where pyproject.toml is)
     - move gh_src\tests tests  # [win]
     - mv gh_src/tests tests    # [not win]
-    # configure flags and docker image name
+    # Configure flags and docker image name (for unix only)
     # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L3-L6
-    - set FLAGS=--maxfail=3    # [win]
-    - set SCALA_VERSION=2.13   # [win]
-    - set KAFKA_VERSION=2.8.1  # [win]
-    - set DOCKER_IMAGE=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION%  # [win]
     - export FLAGS=--maxfail=3    # [not win]
     - export SCALA_VERSION=2.13   # [not win]
     - export KAFKA_VERSION=2.8.1  # [not win]
     - export DOCKER_IMAGE=aiolibs/kafka:$(SCALA_VERSION)_$(KAFKA_VERSION)  # [not win]
     - export LOG_FORMAT="%(asctime)s %(levelname)s %(message)s"            # [not win]    
     # Invoke tests like from the Makefile
-    - echo %DOCKER_IMAGE%   # [win]
-    - echo $(DOCKER_IMAGE)  # [not win]
     # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L59
-    # remove log-format for win as it was problematic, the standard format is fine.
-    - pytest -s -v --log-level DEBUG --docker-image=%DOCKER_IMAGE% %FLAGS% tests    # [win]
+    #
+    # Remove log-format for win as it was problematic, the standard format is fine.
+    # Docker is not available on Windows, do not pass a docker image
+    # to skip its tests (they are fine on unix).
+    - pytest -s -v --log-level DEBUG %FLAGS% tests    # [win]
     - pytest -s -v --log-format="$LOG_FORMAT" --log-level DEBUG --docker-image=$(DOCKER_IMAGE) $(FLAGS) tests  # [not win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,41 +6,72 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 62423895b866f95b5ed8d88335295a37cc5403af64cb7cb0e234f88adc2dff94
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 62423895b866f95b5ed8d88335295a37cc5403af64cb7cb0e234f88adc2dff94
+  - url: https://github.com/aio-libs/aiokafka/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: d71e708393708d00524bd522caabde8b3b488c6fd6e8b96662a60510c22d9f99
+    folder: gh_src
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [win]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython >=3.0.5                         # [build_platform != target_platform]
-    - zlib                                   # [build_platform != target_platform]
     - {{ compiler('c') }}
-    - {{ stdlib("c") }}
+    # - {{ stdlib('c') }}
   host:
     - cython >=3.0.5
     - python
     - pip
-    - setuptools
+    - setuptools >=77
     - zlib
   run:
     - python
     - async-timeout
     - packaging
-    - typing-extensions
+    - typing-extensions >=4.10.0
+  run_constrained:
+    - cramjam >=2.8.0
 
 test:
   imports:
     - aiokafka
   requires:
     - pip
+    - pytest >=8.3.3
+    - pytest-asyncio >=0.24.0
+    - pytest-mock >=3.14.0
+    - docker-py >=7.1.0
+    - cramjam >=2.9.0
+  source_files:
+    - gh_src/tests
+    - pyproject.toml
   commands:
     - pip check
+    # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # move tests in the root folder (where pyproject.toml is)
+    - move gh_src\tests tests  # [win]
+    - mv gh_src/tests tests    # [not win]
+    # configure flags and docker image name
+    # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L3-L6
+    - set FLAGS=--maxfail=3    # [win]
+    - set SCALA_VERSION=2.13   # [win]
+    - set KAFKA_VERSION=2.8.1  # [win]
+    - set DOCKER_IMAGE=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION%  # [win]
+    - export FLAGS=--maxfail=3    # [not win]
+    - export SCALA_VERSION=2.13   # [not win]
+    - export KAFKA_VERSION=2.8.1  # [not win]
+    - export DOCKER_IMAGE=aiolibs/kafka:$(SCALA_VERSION)_$(KAFKA_VERSION)  # [not win]
+    - export LOG_FORMAT="%(asctime)s %(levelname)s %(message)s"            # [not win]    
+    # Invoke tests like from the Makefile
+    - echo %DOCKER_IMAGE%   # [win]
+    - echo $(DOCKER_IMAGE)  # [not win]
+    # see: https://github.com/aio-libs/aiokafka/blob/master/Makefile#L59
+    # remove log-format for win as it was problematic, the standard format is fine.
+    - pytest -s -v --log-level DEBUG --docker-image=%DOCKER_IMAGE% %FLAGS% tests    # [win]
+    - pytest -s -v --log-format="$LOG_FORMAT" --log-level DEBUG --docker-image=$(DOCKER_IMAGE) $(FLAGS) tests  # [not win]
 
 about:
   home: https://github.com/aio-libs/aiokafka
@@ -48,7 +79,6 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: asyncio client for Kafka
-
   description: |
     AIOKafkaProducer is a high-level, asynchronous message producer.
   dev_url: https://github.com/aio-libs/aiokafka

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    # - {{ stdlib('c') }}
+    - {{ stdlib('c') }}
   host:
     - cython >=3.0.5
     - python


### PR DESCRIPTION
[PKG-8878] aiokafka 0.12.0

**Destination channel:** defaults

### Links

- [PKG-8878]
- dev_url (pypi): https://github.com/aio-libs/aiokafka/tree/v0.12.0
- conda-forge: https://github.com/conda-forge/aiokafka-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/aiokafka/0.12.0
- pypi inspector: https://inspector.pypi.io/project/aiokafka/0.12.0

### Explanation of changes:

- new feedstock
- add upstream tests
- [skip docker tests for win](https://github.com/AnacondaRecipes/aiokafka-feedstock/pull/2/commits/dbec3f7568b0170decf68fbf848ec0e7940a563e), there is no docker on Windows images. On unix are fine.
- [skip docker tests](https://github.com/AnacondaRecipes/aiokafka-feedstock/pull/2/commits/f89d4f36e84db65923dcb67a996f3aaf341208b5) for unix as well, for security concerns.

[PKG-8878]: https://anaconda.atlassian.net/browse/PKG-8878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-8878]: https://anaconda.atlassian.net/browse/PKG-8878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ